### PR TITLE
Use an integer expiration for signing S3 urls

### DIFF
--- a/girder_utils/storages.py
+++ b/girder_utils/storages.py
@@ -22,7 +22,7 @@ def expiring_url(storage: Storage, name: str, expiration: timedelta) -> str:
     """
     # Each storage backend uses a slightly different API for URL expiration
     if isinstance(storage, S3Boto3Storage):
-        return storage.url(name, expire=expiration.total_seconds())
+        return storage.url(name, expire=int(expiration.total_seconds()))
     elif isinstance(storage, MinioStorage):
         return storage.url(name, max_age=expiration)
     else:


### PR DESCRIPTION
`generate_presigned_url` takes an `int` for S3, and a `timedelta` for MinIO. Without an `int`, the signatures generated are invalid.

https://github.com/boto/botocore/blob/717eb38a99d0f3eed9648abd62184fbc6a7947ef/botocore/signers.py#L259-L261