### PR TITLE
Remove girder_utils.models

### DIFF
--- a/girder_utils/models.py
+++ b/girder_utils/models.py
@@ -1,8 +1,0 @@
-import warnings
-
-from .db import *  # noqa: F401, F403
-
-warnings.warn(
-    'Imports from "girder_utils.models" should be renamed to use "girder_utils.db"',
-    DeprecationWarning,
-)


### PR DESCRIPTION
The deprecation warning in this compatibility file is getting triggered by Django's auto-importing of every app's "models" module, causing false positives.